### PR TITLE
Fixing a race condition

### DIFF
--- a/cli-shutdown.groovy
+++ b/cli-shutdown.groovy
@@ -33,7 +33,7 @@ p.each { x ->
 }
 
 // disable CLI access over /cli URL
-def removal(lst) {
+def removal = { lst ->
   lst.each { x -> if (x.getClass().name.contains("CLIAction")) lst.remove(x) }
 }
 def j = Jenkins.instance;

--- a/cli-shutdown.groovy
+++ b/cli-shutdown.groovy
@@ -24,6 +24,7 @@ THE SOFTWARE.
 
 import jenkins.*;
 import jenkins.model.*;
+import hudson.model.*;
 
 // disabled CLI access over TCP listener (separate port)
 def p = AgentProtocol.all()
@@ -32,5 +33,9 @@ p.each { x ->
 }
 
 // disable CLI access over /cli URL
+def removal(lst) {
+  lst.each { x -> if (x.getClass().name.contains("CLIAction")) lst.remove(x) }
+}
 def j = Jenkins.instance;
-j.actions.each { x -> if (x.getClass().name.contains("CLIAction")) j.actions.remove(x) }
+removal(j.getExtensionList(RootAction.class))
+removal(j.actions)


### PR DESCRIPTION
Jenkins copies RootAction from ExtensionList to Jenkins.actions, so it needs to be removed in both places.
